### PR TITLE
feat(pubsub): implement messaging.ListenerRemover (closes #71, depends on golly#201)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/storage v1.62.1
 	google.golang.org/api v0.276.0
 	google.golang.org/genai v1.54.0
-	oss.nandlabs.io/golly v1.5.0
+	oss.nandlabs.io/golly v1.5.2-0.20260628114737-7f0f9e6e04b9
 )
 
 require (
@@ -49,12 +49,12 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -161,6 +163,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
@@ -175,10 +179,14 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -230,3 +238,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 oss.nandlabs.io/golly v1.5.0 h1:rWKUaJdq/kkoyKkE1Esy2nRlxA91SrqpyvQ+gOVbDfs=
 oss.nandlabs.io/golly v1.5.0/go.mod h1:dredxTV+G+ycC0qEf91gGrCGU8+jqUDzbYONh8lHUhA=
+oss.nandlabs.io/golly v1.5.2-0.20260628114737-7f0f9e6e04b9 h1:eLDVzeLvLpq4Pr6i8idVZdkidYd+a/VDWNsAq18H6bk=
+oss.nandlabs.io/golly v1.5.2-0.20260628114737-7f0f9e6e04b9/go.mod h1:MOpWwT8vzyROsy4hoFl71FyYbqtyDK0GxU1D8xh9PzM=

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -31,11 +31,22 @@ const (
 
 var pubsubSchemes = []string{PubSubScheme}
 
+// pubsubListenerEntry tracks a single registered listener so it can be
+// individually cancelled by name via RemoveNamedListener, or as part of
+// a per-host group via RemoveListeners.
+type pubsubListenerEntry struct {
+	name   string // empty for unnamed listeners
+	cancel context.CancelFunc
+}
+
 // Provider implements the messaging.Provider interface for Google Cloud Pub/Sub.
+// It also implements messaging.ListenerRemover so callers can detach
+// previously-registered listeners by URL or by named group without
+// closing the entire provider.
 type Provider struct {
-	closed  atomic.Bool
-	mu      sync.Mutex
-	stopFns []context.CancelFunc // cancel functions for active listeners
+	closed    atomic.Bool
+	mu        sync.Mutex
+	listeners map[string][]pubsubListenerEntry // host (subscription) → listeners
 }
 
 // Id returns the provider id.
@@ -321,8 +332,19 @@ func (p *Provider) AddListener(u *url.URL, listener func(msg messaging.Message),
 		ctx, cancel = context.WithTimeout(context.Background(), timeout)
 	}
 
+	// Recognise the "NamedListener" option (same key as golly's
+	// LocalProvider) so RemoveNamedListener works consistently across
+	// providers.
+	var listenerName string
+	if v, ok := messaging.ResolveOptValue[string]("NamedListener", optResolver); ok {
+		listenerName = v
+	}
+
 	p.mu.Lock()
-	p.stopFns = append(p.stopFns, cancel)
+	if p.listeners == nil {
+		p.listeners = make(map[string][]pubsubListenerEntry)
+	}
+	p.listeners[u.Host] = append(p.listeners[u.Host], pubsubListenerEntry{name: listenerName, cancel: cancel})
 	p.mu.Unlock()
 
 	go func() {
@@ -352,10 +374,56 @@ func (p *Provider) Close() error {
 	p.closed.Store(true)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for _, cancel := range p.stopFns {
-		cancel()
+	for _, entries := range p.listeners {
+		for _, e := range entries {
+			e.cancel()
+		}
 	}
-	p.stopFns = nil
+	p.listeners = nil
+	return nil
+}
+
+// RemoveListeners cancels every listener registered for the URL. Other
+// URLs are untouched. Idempotent — returns nil if no listeners are
+// registered. Implements messaging.ListenerRemover.
+func (p *Provider) RemoveListeners(u *url.URL) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	entries, ok := p.listeners[u.Host]
+	if !ok {
+		return nil
+	}
+	for _, e := range entries {
+		e.cancel()
+	}
+	delete(p.listeners, u.Host)
+	return nil
+}
+
+// RemoveNamedListener cancels listeners registered under the given name
+// for the URL. Other listeners on the same URL (including unnamed)
+// keep receiving. Idempotent.
+// Implements messaging.ListenerRemover.
+func (p *Provider) RemoveNamedListener(u *url.URL, name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	entries, ok := p.listeners[u.Host]
+	if !ok {
+		return nil
+	}
+	kept := entries[:0]
+	for _, e := range entries {
+		if e.name == name {
+			e.cancel()
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if len(kept) == 0 {
+		delete(p.listeners, u.Host)
+	} else {
+		p.listeners[u.Host] = kept
+	}
 	return nil
 }
 

--- a/pubsub/pubsub_remove_test.go
+++ b/pubsub/pubsub_remove_test.go
@@ -1,0 +1,113 @@
+package pubsub
+
+import (
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"oss.nandlabs.io/golly/messaging"
+)
+
+// TestProvider_ImplementsListenerRemover is the load-bearing test: as long
+// as Provider satisfies messaging.ListenerRemover, golly's manager-level
+// dispatcher will route RemoveListeners / RemoveNamedListener through us.
+func TestProvider_ImplementsListenerRemover(t *testing.T) {
+	var _ messaging.ListenerRemover = (*Provider)(nil)
+}
+
+func TestProvider_RemoveListeners_IdempotentOnUnknownURL(t *testing.T) {
+	p := &Provider{}
+	u, _ := url.Parse("pubsub://no-such-sub")
+	if err := p.RemoveListeners(u); err != nil {
+		t.Errorf("RemoveListeners on unknown URL should return nil; got %v", err)
+	}
+	if err := p.RemoveNamedListener(u, "anything"); err != nil {
+		t.Errorf("RemoveNamedListener on unknown URL should return nil; got %v", err)
+	}
+}
+
+func TestProvider_RemoveListeners_CancelsTrackedEntries(t *testing.T) {
+	p := &Provider{listeners: map[string][]pubsubListenerEntry{}}
+	u, _ := url.Parse("pubsub://sub1")
+
+	var cancels atomic.Int32
+	mk := func(name string) pubsubListenerEntry {
+		return pubsubListenerEntry{name: name, cancel: func() { cancels.Add(1) }}
+	}
+	p.listeners[u.Host] = []pubsubListenerEntry{mk(""), mk("worker"), mk("worker")}
+
+	if err := p.RemoveListeners(u); err != nil {
+		t.Fatalf("RemoveListeners: %v", err)
+	}
+	if cancels.Load() != 3 {
+		t.Errorf("expected 3 cancel fns invoked; got %d", cancels.Load())
+	}
+	if _, ok := p.listeners[u.Host]; ok {
+		t.Errorf("expected URL entry to be deleted from map")
+	}
+}
+
+func TestProvider_RemoveNamedListener_KeepsOthers(t *testing.T) {
+	p := &Provider{listeners: map[string][]pubsubListenerEntry{}}
+	u, _ := url.Parse("pubsub://sub2")
+
+	var unnamed, kept, dropped atomic.Int32
+	mk := func(counter *atomic.Int32, name string) pubsubListenerEntry {
+		return pubsubListenerEntry{name: name, cancel: func() { counter.Add(1) }}
+	}
+	p.listeners[u.Host] = []pubsubListenerEntry{
+		mk(&unnamed, ""),
+		mk(&kept, "alpha"),
+		mk(&dropped, "beta"),
+		mk(&dropped, "beta"),
+	}
+
+	if err := p.RemoveNamedListener(u, "beta"); err != nil {
+		t.Fatalf("RemoveNamedListener: %v", err)
+	}
+	if dropped.Load() != 2 {
+		t.Errorf("expected 2 'beta' listeners cancelled; got %d", dropped.Load())
+	}
+	if unnamed.Load() != 0 || kept.Load() != 0 {
+		t.Errorf("other listeners should not have been cancelled; unnamed=%d kept=%d",
+			unnamed.Load(), kept.Load())
+	}
+	if len(p.listeners[u.Host]) != 2 {
+		t.Fatalf("expected 2 listeners remaining; got %d", len(p.listeners[u.Host]))
+	}
+}
+
+func TestProvider_RemoveNamedListener_LastEntryDeletesURL(t *testing.T) {
+	p := &Provider{listeners: map[string][]pubsubListenerEntry{}}
+	u, _ := url.Parse("pubsub://sub3")
+	p.listeners[u.Host] = []pubsubListenerEntry{{name: "solo", cancel: func() {}}}
+	if err := p.RemoveNamedListener(u, "solo"); err != nil {
+		t.Fatalf("RemoveNamedListener: %v", err)
+	}
+	if _, ok := p.listeners[u.Host]; ok {
+		t.Errorf("URL entry should be deleted when last listener is removed")
+	}
+}
+
+func TestProvider_RemoveListeners_ConcurrentSafe(t *testing.T) {
+	p := &Provider{listeners: map[string][]pubsubListenerEntry{}}
+	u, _ := url.Parse("pubsub://race")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			p.mu.Lock()
+			p.listeners[u.Host] = append(p.listeners[u.Host], pubsubListenerEntry{cancel: func() {}})
+			p.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = p.RemoveListeners(u)
+		}()
+	}
+	wg.Wait()
+	// No assertion needed beyond -race not firing.
+}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -64,17 +64,17 @@ func TestProvider_Close(t *testing.T) {
 }
 
 func TestProvider_Close_StopsListeners(t *testing.T) {
-	p := &Provider{}
+	p := &Provider{listeners: map[string][]pubsubListenerEntry{}}
 	cancelled := false
-	p.stopFns = append(p.stopFns, func() { cancelled = true })
+	p.listeners["sub"] = []pubsubListenerEntry{{cancel: func() { cancelled = true }}}
 	if err := p.Close(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !cancelled {
 		t.Error("expected cancel function to be called")
 	}
-	if p.stopFns != nil {
-		t.Error("expected stopFns to be nil after Close")
+	if p.listeners != nil {
+		t.Error("expected listeners map to be nil after Close")
 	}
 }
 


### PR DESCRIPTION
## Description

Adds `messaging.ListenerRemover` support to the Pub/Sub provider so callers can detach previously-registered listeners by subscription URL or by named group, instead of having to close the entire provider.

### Related Issue

Closes #71 (this repo).

### ⚠️ Upstream dependency

Depends on **nandlabs/golly#201** — the new optional `messaging.ListenerRemover` interface lives in core golly. `go.mod` here pins golly to that PR's head commit via pseudo-version. **Merge order:**
1. Merge nandlabs/golly#201 and tag a new golly release.
2. Run `go get oss.nandlabs.io/golly@<tag>` here.
3. Mark this PR ready and merge.

Companion: `nandlabs/golly-aws#159` does the same for SQS.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [x] 🔧 Refactoring (Provider listener bookkeeping)
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made

### `pubsub/pubsub.go`

- Refactored `Provider.stopFns []context.CancelFunc` (flat) into a per-subscription map:
  ```go
  type pubsubListenerEntry struct { name string; cancel context.CancelFunc }
  listeners map[string][]pubsubListenerEntry
  ```
- `AddListener` resolves the `"NamedListener"` option (same key golly's `LocalProvider` and the new SQS impl use).
- New `RemoveListeners(u *url.URL) error` — cancels every listener for the subscription host.
- New `RemoveNamedListener(u *url.URL, name string) error` — cancels just the named group.
- Both are idempotent; safe to call concurrently with `AddListener`.
- `Close` now iterates the map; behaviour unchanged from callers' perspective.
- Compile-time assertion: `var _ messaging.ListenerRemover = (*Provider)(nil)`.

### Test updates

- `pubsub_test.go::TestProvider_Close_StopsListeners` — updated to construct the new `listeners` map shape.
- `pubsub_remove_test.go` (new) — 6 tests covering interface satisfaction, idempotent no-op, cancellation of tracked entries, named removal preserving others, last-entry cleanup, and concurrent registration + removal under `-race`.

The new tests bypass the GCP SDK by injecting entries directly into `p.listeners` — no fake Pub/Sub emulator needed.

### `go.mod`

Bumped `oss.nandlabs.io/golly` to the golly#201 pseudo-version. Re-bump to a tagged release before merge.

### Backward compatibility

- Existing callers of `AddListener` see no change.
- `Close` semantics unchanged from caller perspective.
- `RemoveListeners` / `RemoveNamedListener` are purely additive.

## Testing

```
$ GOWORK=off go test -race ./...
ok  oss.nandlabs.io/golly-gcp/gcpsvc
ok  oss.nandlabs.io/golly-gcp/genai
ok  oss.nandlabs.io/golly-gcp/gs
ok  oss.nandlabs.io/golly-gcp/pubsub  # +6 new tests, 1 updated
ok  oss.nandlabs.io/golly-gcp/secrets
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (godoc on new methods)
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license
